### PR TITLE
0 index Array

### DIFF
--- a/src/TreeWalker.php
+++ b/src/TreeWalker.php
@@ -249,7 +249,7 @@ class TreeWalker
             foreach ($assocarray as $key => $value) {
                 if (array_key_exists($key, $assocarray)) {
 
-                    $path = $currentpath ? $currentpath . "/" . $key : $key;
+                    $path = $currentpath !== '' ? $currentpath . "/" . $key : sprintf($key);
 
                     if (gettype($assocarray[$key]) == "array" && !empty($assocarray[$key])) {
                         $this->structPathArray($assocarray[$key], $array, $path);


### PR DESCRIPTION
If the first object is an array, $path is build with a '0' (integer) index, that does not pass the first '$currentpath == ''' ternal.
Force type comparison (!==) and 'cast' 0 to string (sprintf($key))